### PR TITLE
call python2 instead of python for backward compatibility

### DIFF
--- a/benchmarking.py
+++ b/benchmarking.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import sys, re, time, random, pprint
 import numpy

--- a/bm_scripts/bm_fir_filters.py
+++ b/bm_scripts/bm_fir_filters.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import numpy
 from gnuradio import gr, blocks, filter

--- a/bm_scripts/bm_noise.py
+++ b/bm_scripts/bm_noise.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 from gnuradio import gr, blocks, analog
 

--- a/bm_scripts/bm_pskdemod.py
+++ b/bm_scripts/bm_pskdemod.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 from gnuradio import gr, blocks, digital, analog
 from gnuradio.filter import firdes

--- a/bm_scripts/bm_pskmod.py
+++ b/bm_scripts/bm_pskmod.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 from gnuradio import gr, blocks, digital, analog
 import random, numpy

--- a/bm_scripts/bm_sig_source.py
+++ b/bm_scripts/bm_sig_source.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 from gnuradio import gr, blocks, analog
 

--- a/gr_profiler.py
+++ b/gr_profiler.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 import sys, subprocess, os, re, shlex
 import argparse
 from argparse import ArgumentParser
@@ -152,7 +152,7 @@ def main():
     if(options.dw):
         print "executing GR waveform benchmarks ..."
         results_fname = "profile_results.dat"
-        wfstdout = shellexec_getout("python benchmarking.py -F gr_profiler.json -o %s"%(results_fname),print_err=True)
+        wfstdout = shellexec_getout("python2 benchmarking.py -F gr_profiler.json -o %s"%(results_fname),print_err=True)
         with open(results_fname,"rb") as fp:
             wfperf = pickle.load(fp)
         wfperf = json.dumps(wfperf)

--- a/plot_results.py
+++ b/plot_results.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import numpy
 import re


### PR DESCRIPTION
this change ensures proper functionality on systems with python 3.x as
default interpreter